### PR TITLE
Allow bundle task to be disabled for release (#18892)

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -76,9 +76,11 @@ afterEvaluate {
                     "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
             }
 
-            enabled config."bundleIn${targetName}" ||
-                config."bundleIn${variant.buildType.name.capitalize()}" ?:
-                targetName.toLowerCase().contains("release")
+            enabled config."bundleIn${targetName}" != null
+              ? config."bundleIn${targetName}"
+              : config."bundleIn${buildTypeName.capitalize()}" != null
+                ? config."bundleIn${buildTypeName.capitalize()}"
+                : targetName.toLowerCase().contains("release")
         }
 
         // Expose a minimal interface on the application variant and the task itself:


### PR DESCRIPTION
Summary:
The current system would always end up falling back to `true` for release builds
Pull Request resolved: https://github.com/facebook/react-native/pull/18892

Differential Revision: D14069444

Pulled By: hramos

fbshipit-source-id: 16e32a366b3b2e252a98a967da827ba1ebaeff85

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
