### PR TITLE
fix for iOS13 + XCode11

### DIFF
--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -91,7 +91,8 @@ static BOOL RCTParseSelectorPart(const char **input, NSMutableString *selector)
 static BOOL RCTParseUnused(const char **input)
 {
   return RCTReadString(input, "__attribute__((unused))") ||
-         RCTReadString(input, "__unused");
+       RCTReadString(input, "__attribute__((__unused__))") ||
+       RCTReadString(input, "__unused");
 }
 
 static RCTNullability RCTParseNullability(const char **input)
@@ -143,20 +144,20 @@ NSString *RCTParseMethodSignature(const char *input, NSArray<RCTMethodArgument *
     // Parse type
     if (RCTReadChar(&input, '(')) {
       RCTSkipWhitespace(&input);
-      
+
       // 5 cases that both nullable and __unused exist
       // 1: foo:(nullable __unused id)foo 2: foo:(nullable id __unused)foo
       // 3: foo:(__unused id _Nullable)foo 4: foo:(id __unused _Nullable)foo
       // 5: foo:(id _Nullable __unused)foo
       RCTNullability nullability = RCTParseNullability(&input);
       RCTSkipWhitespace(&input);
-      
+
       BOOL unused = RCTParseUnused(&input);
       RCTSkipWhitespace(&input);
 
       NSString *type = RCTParseType(&input);
       RCTSkipWhitespace(&input);
-      
+
       if (nullability == RCTNullabilityUnspecified) {
         nullability = RCTParseNullabilityPostfix(&input);
         RCTSkipWhitespace(&input);


### PR DESCRIPTION
to work with iOS13, we need XCode11. to use XCode11, we need to fix a bug in RN ( < 0.59.8 )

or we will run into error like "Unknown argument type __attribute __ in method" when starting our app.

see this post for the bug:https://github.com/facebook/react-native/issues/25138
this pr for the fix: https://github.com/facebook/react-native/pull/25146/files

tested with XCode11,  build into iphoneX which I upgrade to use iOS13.


NOTE: I haven't tested with older version of XCode or older version if iOS, but the change seems safe to me.

when can we move back to official release of RN ? we do have another pr:https://github.com/ubiquity6/react-native/pull/1/files fix the same thing, it's just never merged.
