### PR TITLE
WebSocket errors use Trace not Log

### DIFF
--- a/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/React/Inspector/RCTInspectorPackagerConnection.m
@@ -306,7 +306,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   // Don't log ECONNREFUSED at all; it's expected in cases where the server isn't listening.
   if (![cause.domain isEqual:NSPOSIXErrorDomain] || cause.code != ECONNREFUSED) {
-    RCTLogInfo(@"Error occurred, shutting down websocket connection: %@ %@", message, cause);
+    RCTLogTrace(@"Error occurred, shutting down websocket connection: %@ %@", message, cause);
   }
 
   [self closeAllConnections];


### PR DESCRIPTION
This line is causing a lot of debug spew on our IOS app.  This change makes it Trace not Log, so its not spewed by default.